### PR TITLE
add light mode

### DIFF
--- a/components/nav.js
+++ b/components/nav.js
@@ -4,6 +4,7 @@ import { useState, useRef } from "react";
 import Sidebar from "./sidebar";
 import { useData } from "../Context/dataContext";
 import { getNavByPath } from "../helper/navigations";
+import ToogleLight from "./toggle-light";
 
 export default function Nav() {
   const [showSidebar, setShowSidebar] = useState(false);
@@ -23,7 +24,7 @@ export default function Nav() {
   )}
 
   return (
-    <div>
+    <div className="relative">
       <Sidebar
         Ref={ref}
         showSidebar={showSidebar}
@@ -58,6 +59,7 @@ export default function Nav() {
           <NavLink pathName='/login' label='Login'  />
         </div>
       </nav>
+      <ToogleLight />
     </div>
   );
 }

--- a/components/toggle-light.js
+++ b/components/toggle-light.js
@@ -1,0 +1,13 @@
+import React from "react"
+
+export default function ToogleLight() {
+  const [isLightMode, setIsLightMode] = React.useState(false);
+  const onToogleLightMode = () => {
+    document.documentElement.classList.toggle("light-mode");
+    setIsLightMode(document.documentElement.classList.contains("light-mode"));
+  }
+
+  return <div onClick={onToogleLightMode} className="absolute top-12 w-8 h-4 bg-opink rounded-lg cursor-pointer ">
+    <div className={`transition-all	rounded-full bg-owhite w-4 h-4 ${isLightMode && 'ml-4'}`} />
+    </div>
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,8 +2,24 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
+:root {
+    --bg: hsl(216, 15%, 13%);
+    --dark: #1D2127;
+    --opink: #F999CB;
+    --owhite: #FFFFFF;
+    --dblue: #32384;
+}
+
+.light-mode {
+    --bg: #becbdf;
+    --dark: #FFFFFF;
+    --owhite: #1D2127;
+    --dblue: #32384;
+    color: #fff;
+}
+
 html {
-    background-color: hsl(216, 15%, 13%) ;
+    background-color: theme('colors.bg');
     font-family: system-ui;
     font-family: 'Inconsolata', monospace;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,10 +6,11 @@ module.exports = {
   ],
   theme: {
     colors: {
-      dark: "#1D2127",
-      opink: "#F999CB",
-      owhite: "#FFFFFF",
-      dblue: "#323843",
+      bg: "var(--bg)",
+      dark: "var(--dark)",
+      opink: "var(--opink)",
+      owhite: "var(--owhite)",
+      dblue: "var(--dblue)",
     },
     extend: {
       fontFamily: {


### PR DESCRIPTION
#19 

Add Light Mode with toggle button


https://user-images.githubusercontent.com/11053039/197066306-621a035d-9386-481c-8aae-9ff2eaa52ea1.mov


## Disclaimers ⚠️ 
-  I couldn't find the light colors in figma.
- The light-mode colors was added just flipping dark mode color.
- I took the dare to add a ToggleButton that is not in the designs.


## How to use it?
- Add color variable in `global.css`
``` css
:root {
    --bg: hsl(216, 15%, 13%);
    --dark: #1D2127;
    --opink: #F999CB;
    --owhite: #FFFFFF;
    --dblue: #32384;
}

.light-mode {
    --bg: #becbdf;
    --dark: #FFFFFF;
    --owhite: #1D2127;
    --dblue: #32384;
    color: #fff;
}
```

- Add Color variable in `tailwind.config.js` with `var` selector.
``` 
  theme: {
    colors: {
      bg: "var(--bg)",
      dark: "var(--dark)",
      opink: "var(--opink)",
      owhite: "var(--owhite)",
      dblue: "var(--dblue)",
    },
```
- Its ready you can use with both themes


